### PR TITLE
Bugfix 7023/Improve error handling when localization not found for category

### DIFF
--- a/__tests__/__snapshots__/groupsIndexParser.test.js.snap
+++ b/__tests__/__snapshots__/groupsIndexParser.test.js.snap
@@ -298,7 +298,10 @@ Object {
 `;
 
 exports[`tests groupsIndexParser.generateGroupsIndex() test error handling 1`] = `
-[Error: generateGroupsIndex() - error processing index:
-error processing entry: bookid: gal, groupDataFile: translate-numbers.json, taArticleCategory: translate, groupName: null: Error: ENOENT: no such file or directory, open 'translate/translate-numbers.md'
-error processing entry: bookid: tit, groupDataFile: figs-hypo.json, taArticleCategory: translate, groupName: null: Error: ENOENT: no such file or directory, open 'translate/figs-hypo.md']
+Array [
+  "generateGroupsIndex() - error finding group name: groupId: 'translate-numbers', index: '0' in bookId 'gal, taArticleCategory: translate' ",
+  "Could not find localization for translate-numbers, adding stub entry",
+  "generateGroupsIndex() - error finding group name: groupId: 'figs-hypo', index: '0' in bookId 'tit, taArticleCategory: translate' ",
+  "Could not find localization for figs-hypo, adding stub entry",
+]
 `;

--- a/__tests__/__snapshots__/groupsIndexParser.test.js.snap
+++ b/__tests__/__snapshots__/groupsIndexParser.test.js.snap
@@ -300,8 +300,8 @@ Object {
 exports[`tests groupsIndexParser.generateGroupsIndex() test error handling 1`] = `
 Array [
   "generateGroupsIndex() - error finding group name: groupId: 'translate-numbers', index: '0' in bookId 'gal, taArticleCategory: translate' ",
-  "Could not find localization for translate-numbers, adding stub entry",
+  "Could not find localization for 'translate-numbers' in 'numbers', adding stub entry",
   "generateGroupsIndex() - error finding group name: groupId: 'figs-hypo', index: '0' in bookId 'tit, taArticleCategory: translate' ",
-  "Could not find localization for figs-hypo, adding stub entry",
+  "Could not find localization for 'figs-hypo' in 'numbers', adding stub entry",
 ]
 `;

--- a/__tests__/groupsIndexParser.test.js
+++ b/__tests__/groupsIndexParser.test.js
@@ -2,6 +2,11 @@ jest.unmock('fs-extra')
 import { generateGroupsIndex, getArticleCategory } from '../src/groupsIndexParser'
 
 describe('tests groupsIndexParser.generateGroupsIndex()', () => {
+  let save_console = null;
+
+  beforeEach(() => {
+    save_console = global.console;
+  });
   test('returns an object with all the tn categories, each one with their groupsIndex', () => {
     const tnCategoriesPath = '__tests__/fixtures/resources/en/translationHelps/translationNotes/v14'
     const taCategoriesPath = '__tests__/fixtures/resources/en/translationHelps/translationAcademy/v10'
@@ -10,6 +15,8 @@ describe('tests groupsIndexParser.generateGroupsIndex()', () => {
   })
 
   test('test error handling', () => {
+    const errorLog = []
+    global.console = { error: jest.fn(e => errorLog.push(e)), log: jest.fn() } // mock console
     const tnCategoriesPath = '__tests__/fixtures/shortTn/translationNotes/v14'
     const taCategoriesPath = ''
     let error = null
@@ -18,8 +25,15 @@ describe('tests groupsIndexParser.generateGroupsIndex()', () => {
     } catch (e) {
       error = e;
     }
-    expect(error).toMatchSnapshot()
+    expect(error).toBeNull() // no unrecoverable errors
+    expect(errorLog).toMatchSnapshot() // verify recoverable errors
   })
+
+  afterEach(() => {
+    if (save_console) {
+      global.console = save_console; // restore unmocked
+    }
+  });
 })
 
 describe('tests groupsIndexParser.getArticleCategory()', () => {

--- a/__tests__/groupsIndexParser.test.js
+++ b/__tests__/groupsIndexParser.test.js
@@ -6,7 +6,8 @@ describe('tests groupsIndexParser.generateGroupsIndex()', () => {
 
   beforeEach(() => {
     save_console = global.console;
-  });
+  })
+
   test('returns an object with all the tn categories, each one with their groupsIndex', () => {
     const tnCategoriesPath = '__tests__/fixtures/resources/en/translationHelps/translationNotes/v14'
     const taCategoriesPath = '__tests__/fixtures/resources/en/translationHelps/translationAcademy/v10'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsv-groupdata-parser",
-  "version": "0.9.17-alpha",
+  "version": "0.9.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsv-groupdata-parser",
-  "version": "0.9.16",
+  "version": "0.9.17-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsv-groupdata-parser",
-  "version": "0.9.16",
+  "version": "0.9.17-alpha",
   "description": "Parses the translationNotes TSVs files to generate the GroupIndex and GroupData for the translationCore Desktop app.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsv-groupdata-parser",
-  "version": "0.9.17-alpha",
+  "version": "0.9.17",
   "description": "Parses the translationNotes TSVs files to generate the GroupIndex and GroupData for the translationCore Desktop app.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -5,9 +5,9 @@ import { getGroupName } from './helpers/resourcesHelpers';
 /**
  * make sure this groupId is in a category
  * @param {String} groupId
- * @param {String} groupName
+ * @param {String} groupName - localized group name
  * @param {Object} categorizedGroupsIndex
- * @param {String} categoryName
+ * @param {String} categoryName - category that should contain this groupId
  */
 const addGroupToCategory = (groupId, groupName, categorizedGroupsIndex, categoryName) => {
   const groupIndexItem = getGroupIndex(groupId, groupName);

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -2,7 +2,18 @@ import fs from 'fs-extra';
 import path from 'path-extra';
 import { getGroupName } from './helpers/resourcesHelpers';
 
-const addGroupToCategory = (groupId, groupName, categorizedGroupsIndex, categoryName) => {
+/**
+ * take this category and make sure it is in a group
+ * @param {String} groupId
+ * @param {Object} categorizedGroupsIndex
+ * @param {String} categoryName
+ * @param {String} taCategoriesPath
+ * @param {String} taArticleCategory
+ */
+const addCategoryToGroup = (groupId, categorizedGroupsIndex, categoryName,taCategoriesPath, taArticleCategory) => {
+  const fileName = groupId + '.md';
+  const articlePath = path.join(taCategoriesPath, taArticleCategory, fileName);
+  const groupName = getGroupName(articlePath);
   const groupIndexItem = getGroupIndex(groupId, groupName);
 
   // Only add the groupIndexItem if it isn't already in the category's groups index.
@@ -51,25 +62,22 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
 
               try {
                 if (!taArticleCategory) {
-                  throw `Link in Occurrence Note ${contextId.occurrenceNote} does not have category for check at index: ${i}`;
+                  throw new Error(`Link in Occurrence Note ${contextId.occurrenceNote} does not have category for check at index: ${i}`);
                 }
 
-                const fileName = groupId + '.md';
-                const articlePath = path.join(taCategoriesPath, taArticleCategory, fileName);
-                groupName = getGroupName(articlePath);
-                addGroupToCategory(groupId, groupName, categorizedGroupsIndex, categoryName);
+                addCategoryToGroup(groupId, categorizedGroupsIndex, categoryName, taCategoriesPath, taArticleCategory);
                 categoryFound = true;
                 break; // we got the category, so don't need to search anymore
               } catch (e) {
-                let message = `error finding group name: groupId: ${groupId}, index: ${i} `;
+                let message = `error finding group name: groupId: ${groupId}, index: ${i} in bookId ${bookid} `;
                 console.error('generateGroupsIndex() - ' + message, e);
                 errors.push(message + e.toString());
               }
             }
 
             if (!categoryFound) {
-              addGroupToCategory('other', 'other', categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
-              throw `Could not find category for ${groupId}`;
+              addCategoryToGroup('other', categorizedGroupsIndex, categoryName, taCategoriesPath, taArticleCategory); // add entry even though we could not find localized description
+              throw new Error(`Could not find category for ${groupId}`);
             }
           }
         } catch (e) {

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -50,7 +50,6 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
           taArticleCategory = null;
           groupName = null;
           let foundLocalization = false;
-          let lastError = null;
 
           if (groupData.length > 0) {
             for (let i = 0; i < groupData.length; i++ ) {
@@ -71,17 +70,12 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
               } catch (e) {
                 let message = `error finding group name: groupId: '${groupId}', index: '${i}' in bookId '${bookid}, taArticleCategory: ${taArticleCategory}' `;
                 console.error('generateGroupsIndex() - ' + message, e);
-                lastError = e;
               }
             }
 
             if (!foundLocalization) {
               addGroupToCategory(groupId, groupId, categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
               console.error(`Could not find localization for ${groupId}, adding stub entry`);
-
-              if (lastError) { // throw last error to keep track of failures
-                throw lastError;
-              }
             }
           }
         } catch (e) {

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -75,7 +75,7 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
             }
 
             if (!categoryFound) {
-              addGroupToCategory('other', 'Other', categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
+              addGroupToCategory(groupId, groupId, categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
               throw `Could not find category for ${groupId}`;
             }
           }

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -50,6 +50,7 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
           taArticleCategory = null;
           groupName = null;
           let foundLocalization = false;
+          let lastError = null;
 
           if (groupData.length > 0) {
             for (let i = 0; i < groupData.length; i++ ) {
@@ -70,12 +71,17 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
               } catch (e) {
                 let message = `error finding group name: groupId: '${groupId}', index: '${i}' in bookId '${bookid}, taArticleCategory: ${taArticleCategory}' `;
                 console.error('generateGroupsIndex() - ' + message, e);
+                lastError = e;
               }
             }
 
             if (!foundLocalization) {
               addGroupToCategory(groupId, groupId, categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
-              console.error(`Could not find category for ${groupId}, setting to default`);
+              console.error(`Could not find localization for ${groupId}, adding stub entry`);
+
+              if (lastError) { // throw last error to keep track of failures
+                throw lastError;
+              }
             }
           }
         } catch (e) {

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -3,7 +3,7 @@ import path from 'path-extra';
 import { getGroupName } from './helpers/resourcesHelpers';
 
 /**
- * take this category and make sure it is in a group
+ * make sure this groupId is in a category
  * @param {String} groupId
  * @param {String} groupName
  * @param {Object} categorizedGroupsIndex
@@ -75,7 +75,7 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
 
             if (!foundLocalization) {
               addGroupToCategory(groupId, groupId, categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
-              console.error(`Could not find localization for ${groupId}, adding stub entry`);
+              console.error(`Could not find localization for '${groupId}' in '${categoryName}', adding stub entry`);
             }
           }
         } catch (e) {

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -46,11 +46,12 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
 
           if (groupData.length > 0) {
             for (let i = 0; i < groupData.length; i++ ) {
-              taArticleCategory = getArticleCategory(groupData[0].contextId.occurrenceNote, groupId);
+              const contextId = groupData[i].contextId;
+              taArticleCategory = getArticleCategory(contextId.occurrenceNote, groupId);
 
               try {
-                if (taArticleCategory !== groupId) {
-                  throw `Link in Occurrence Note ${taArticleCategory} does not match GroupID ${groupId} for check at index: ${i}`;
+                if (!taArticleCategory) {
+                  throw `Link in Occurrence Note ${contextId.occurrenceNote} does not have category for check at index: ${i}`;
                 }
 
                 const fileName = groupId + '.md';
@@ -67,7 +68,7 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
             }
 
             if (!categoryFound) {
-              addGroupToCategory(groupId, groupId, categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
+              addGroupToCategory('other', 'other', categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
               throw `Could not find category for ${groupId}`;
             }
           }

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -5,15 +5,11 @@ import { getGroupName } from './helpers/resourcesHelpers';
 /**
  * take this category and make sure it is in a group
  * @param {String} groupId
+ * @param {String} groupName
  * @param {Object} categorizedGroupsIndex
  * @param {String} categoryName
- * @param {String} taCategoriesPath
- * @param {String} taArticleCategory
  */
-const addCategoryToGroup = (groupId, categorizedGroupsIndex, categoryName,taCategoriesPath, taArticleCategory) => {
-  const fileName = groupId + '.md';
-  const articlePath = path.join(taCategoriesPath, taArticleCategory, fileName);
-  const groupName = getGroupName(articlePath);
+const addGroupToCategory = (groupId, groupName, categorizedGroupsIndex, categoryName) => {
   const groupIndexItem = getGroupIndex(groupId, groupName);
 
   // Only add the groupIndexItem if it isn't already in the category's groups index.
@@ -65,7 +61,10 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
                   throw new Error(`Link in Occurrence Note '${contextId.occurrenceNote}' does not have category for check at index: ${i}`);
                 }
 
-                addCategoryToGroup(groupId, categorizedGroupsIndex, categoryName, taCategoriesPath, taArticleCategory);
+                const fileName = groupId + '.md';
+                const articlePath = path.join(taCategoriesPath, taArticleCategory, fileName);
+                groupName = getGroupName(articlePath);
+                addGroupToCategory(groupId, groupName, categorizedGroupsIndex, categoryName);
                 categoryFound = true;
                 break; // we got the category, so don't need to search anymore
               } catch (e) {
@@ -76,8 +75,8 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
             }
 
             if (!categoryFound) {
-              addCategoryToGroup(groupId, categorizedGroupsIndex, categoryName, taCategoriesPath, 'other'); // add entry even though we could not find localized description
-              throw new Error(`Could not find category for '${groupId}'`);
+              addGroupToCategory('other', 'Other', categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
+              throw `Could not find category for ${groupId}`;
             }
           }
         } catch (e) {

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -62,22 +62,22 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
 
               try {
                 if (!taArticleCategory) {
-                  throw new Error(`Link in Occurrence Note ${contextId.occurrenceNote} does not have category for check at index: ${i}`);
+                  throw new Error(`Link in Occurrence Note '${contextId.occurrenceNote}' does not have category for check at index: ${i}`);
                 }
 
                 addCategoryToGroup(groupId, categorizedGroupsIndex, categoryName, taCategoriesPath, taArticleCategory);
                 categoryFound = true;
                 break; // we got the category, so don't need to search anymore
               } catch (e) {
-                let message = `error finding group name: groupId: ${groupId}, index: ${i} in bookId ${bookid} `;
+                let message = `error finding group name: groupId: '${groupId}', index: '${i}' in bookId '${bookid}' `;
                 console.error('generateGroupsIndex() - ' + message, e);
                 errors.push(message + e.toString());
               }
             }
 
             if (!categoryFound) {
-              addCategoryToGroup('other', categorizedGroupsIndex, categoryName, taCategoriesPath, taArticleCategory); // add entry even though we could not find localized description
-              throw new Error(`Could not find category for ${groupId}`);
+              addCategoryToGroup(groupId, categorizedGroupsIndex, categoryName, taCategoriesPath, 'other'); // add entry even though we could not find localized description
+              throw new Error(`Could not find category for '${groupId}'`);
             }
           }
         } catch (e) {

--- a/src/groupsIndexParser.js
+++ b/src/groupsIndexParser.js
@@ -49,7 +49,7 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
           const groupData = fs.readJsonSync(filePath);
           taArticleCategory = null;
           groupName = null;
-          let categoryFound = false;
+          let foundLocalization = false;
 
           if (groupData.length > 0) {
             for (let i = 0; i < groupData.length; i++ ) {
@@ -65,18 +65,17 @@ export const generateGroupsIndex = (tnCategoriesPath, taCategoriesPath) => {
                 const articlePath = path.join(taCategoriesPath, taArticleCategory, fileName);
                 groupName = getGroupName(articlePath);
                 addGroupToCategory(groupId, groupName, categorizedGroupsIndex, categoryName);
-                categoryFound = true;
+                foundLocalization = true;
                 break; // we got the category, so don't need to search anymore
               } catch (e) {
-                let message = `error finding group name: groupId: '${groupId}', index: '${i}' in bookId '${bookid}' `;
+                let message = `error finding group name: groupId: '${groupId}', index: '${i}' in bookId '${bookid}, taArticleCategory: ${taArticleCategory}' `;
                 console.error('generateGroupsIndex() - ' + message, e);
-                errors.push(message + e.toString());
               }
             }
 
-            if (!categoryFound) {
+            if (!foundLocalization) {
               addGroupToCategory(groupId, groupId, categorizedGroupsIndex, categoryName); // add entry even though we could not find localized description
-              throw `Could not find category for ${groupId}`;
+              console.error(`Could not find category for ${groupId}, setting to default`);
             }
           }
         } catch (e) {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated tsv-groupdata-parser and added safe error recovery for when we cannot look up localized group name for groupId

#### Please include detailed Test instructions for your pull request:
- test with build attached to `https://github.com/unfoldingWord/translationCore/pull/7027`
- delete en tn from resources folder
- do update of en resources - should succeed
